### PR TITLE
Pulled HTTP related code into own class (BrainHttp).  Refactored GH_Cmponent_HTTPAsync to remove duplicate code.

### DIFF
--- a/src/Brain.csproj.bak
+++ b/src/Brain.csproj.bak
@@ -7,10 +7,6 @@
     <Description>Description of brain_ghplugin</Description>
     <TargetExt>.gha</TargetExt>
   </PropertyGroup>
-	
-  <ItemGroup>
-    <PackageReference Include="Grasshopper" Version="7.28.23058.3001" />
-  </ItemGroup>
   
   <ItemGroup>
     <Reference Include="System.Windows.Forms" />
@@ -20,7 +16,7 @@
     <StartProgram>C:\Program Files\Rhino 7\System\Rhino.exe</StartProgram>
     <StartArguments>/runscript="_-RunScript (
         Set GH = Rhino.GetPlugInObject(""Grasshopper"") 
-        Call GH.OpenDocument("".\brain-plugin-grasshopper\tests\testing_workbench.ghx"")
+        Call GH.OpenDocument(""D:\Dropbox\JL\code\ParametricCamp\brain-plugin-grasshopper\tests\testing_workbench.ghx"")
       )"</StartArguments>
     <StartAction>Program</StartAction>
   </PropertyGroup>

--- a/src/HTTP/BrainHttp.cs
+++ b/src/HTTP/BrainHttp.cs
@@ -1,0 +1,53 @@
+﻿using System.Net;
+using System.Text;
+
+namespace Brain.HTTP
+{
+    public class BrainHttp
+    {
+        internal WebResponse GetWebResponseFromGet(string url, string authorization, int timeout)
+        {
+            var request = CreateBaseRequest(url, "GET", authorization, timeout);
+
+            return request.GetResponse();
+        }
+        internal WebResponse GetWebResponseFromPost(string body, string url, string contentType, string authorization, int timeout)
+        {
+            // Compose the request
+            byte[] data = Encoding.ASCII.GetBytes(body);
+
+            var request = CreateBaseRequest(url, "POST", authorization, timeout);
+
+            request.ContentType = contentType;
+            request.ContentLength = data.Length;
+
+            return request.GetResponse();
+        }
+
+        private HttpWebRequest CreateBaseRequest(string url, string method, string authorization, int timeout)
+        {
+            HttpWebRequest request = (HttpWebRequest)WebRequest.Create(url);
+
+            request.Method = method;
+            request.Timeout = timeout;
+
+            // Handle authorization
+            if (authorization != null && authorization.Length > 0)
+            {
+                ServicePointManager.Expect100Continue = true;
+                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12; //the auth type
+
+                request.PreAuthenticate = true;
+                request.Headers.Add("Authorization", authorization);
+            }
+            else
+            {
+                request.Credentials = CredentialCache.DefaultCredentials;
+            }
+
+            return request;
+        }
+
+
+    }
+}

--- a/src/Templates/GH_Component_HTTPAsync.cs
+++ b/src/Templates/GH_Component_HTTPAsync.cs
@@ -1,18 +1,17 @@
-﻿using Grasshopper.Kernel;
+﻿using Brain.HTTP;
+using Grasshopper.Kernel;
 using Rhino;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
-using static System.Windows.Forms.VisualStyles.VisualStyleElement.Tab;
 
 namespace Brain.Templates
 {
     public abstract class GH_Component_HTTPAsync : GH_Component
     {
+        private readonly BrainHttp _http;
+
         protected string _response = "";
         protected bool _shouldExpire = false;
         protected RequestState _currentState = RequestState.Off;
@@ -20,6 +19,7 @@ namespace Brain.Templates
         public GH_Component_HTTPAsync(string name, string nickname, string description, string category, string subcategory)
     : base(name, nickname, description, category, subcategory)
         {
+            _http = new BrainHttp();
         }
 
         protected override void ExpireDownStreamObjects()
@@ -30,6 +30,15 @@ namespace Brain.Templates
             }
         }
 
+        protected void GETAsync(
+            string url,
+            string authorization,
+            int timeout)
+        {
+            GetWebResponse(() => _http
+            .GetWebResponseFromGet(url, authorization, timeout));
+        }
+
         protected void POSTAsync(
             string url,
             string body,
@@ -37,106 +46,32 @@ namespace Brain.Templates
             string authorization,
             int timeout)
         {
-            Task.Run(() =>
-            {
-                try
-                {
-                    // Compose the request
-                    byte[] data = Encoding.ASCII.GetBytes(body);
-
-                    HttpWebRequest request = (HttpWebRequest)WebRequest.Create(url);
-                    request.Method = "POST";
-                    request.ContentType = contentType;
-                    request.ContentLength = data.Length;
-                    request.Timeout = timeout;
-
-                    // Handle authorization
-                    if (authorization != null && authorization.Length > 0)
-                    {
-                        System.Net.ServicePointManager.Expect100Continue = true;
-                        System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12; //the auth type
-
-                        request.PreAuthenticate = true;
-                        request.Headers.Add("Authorization", authorization);
-                    }
-                    else
-                    {
-                        request.Credentials = CredentialCache.DefaultCredentials;
-                    }
-
-                    using (var stream = request.GetRequestStream())
-                    {
-                        stream.Write(data, 0, data.Length);
-                    }
-                    var res = request.GetResponse();
-                    _response = new StreamReader(res.GetResponseStream()).ReadToEnd();
-
-                    _currentState = RequestState.Done;
-
-                    _shouldExpire = true;
-                    RhinoApp.InvokeOnUiThread((Action)delegate { ExpireSolution(true); });
-                }
-                catch (Exception ex)
-                {
-                    _response = ex.Message;
-
-                    _currentState = RequestState.Error;
-
-                    _shouldExpire = true;
-                    RhinoApp.InvokeOnUiThread((Action)delegate { ExpireSolution(true); });
-
-                    return;
-                }
-            });
+            GetWebResponse(() => _http
+                .GetWebResponseFromPost(body, url, contentType, authorization, timeout));
         }
 
-
-        protected void GETAsync(
-            string url,
-            string authorization,
-            int timeout)
+        private void GetWebResponse(Func<WebResponse> getAsyncWebResponse)
         {
             Task.Run(() =>
             {
                 try
                 {
-                    // Compose the request
-                    HttpWebRequest request = (HttpWebRequest)WebRequest.Create(url);
-                    request.Method = "GET";
-                    request.Timeout = timeout;
-
-                    // Handle authorization
-                    if (authorization != null && authorization.Length > 0)
-                    {
-                        System.Net.ServicePointManager.Expect100Continue = true;
-                        System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12; //the auth type
-
-                        request.PreAuthenticate = true;
-                        request.Headers.Add("Authorization", authorization);
-                    }
-                    else
-                    {
-                        request.Credentials = CredentialCache.DefaultCredentials;
-                    }
-
-                    var res = request.GetResponse();
-                    _response = new StreamReader(res.GetResponseStream()).ReadToEnd();
-
+                    var response = getAsyncWebResponse.Invoke();
+      
+                    _response = new StreamReader(response.GetResponseStream()).ReadToEnd();
                     _currentState = RequestState.Done;
-
-                    _shouldExpire = true;
-                    RhinoApp.InvokeOnUiThread((Action)delegate { ExpireSolution(true); });
                 }
                 catch (Exception ex)
                 {
                     _response = ex.Message;
-
                     _currentState = RequestState.Error;
 
+                    return;
+                }
+                finally
+                {
                     _shouldExpire = true;
                     RhinoApp.InvokeOnUiThread((Action)delegate { ExpireSolution(true); });
-
-                    return;
                 }
             });
         }


### PR DESCRIPTION
Some changes in the csproj file can be ignored.

The goal of this was to create a smaller footprint in the template files.